### PR TITLE
Task flexible time period

### DIFF
--- a/PostNewQuestions.php
+++ b/PostNewQuestions.php
@@ -32,6 +32,11 @@ class PostNewQuestions
     protected string $apiTagUrl = 'https://api.stackexchange.com/2.2/questions?site=stackoverflow&filter=withbody&order=asc';
 
     /**
+     * @var string
+     */
+    protected string $fileWithTimestampOfLastExecution = 'last_execution.txt';
+
+    /**
      * @var array
      */
     protected array $webhooks = [];
@@ -127,11 +132,19 @@ class PostNewQuestions
      */
     public function getNewestPostsInStackOverflow(string $tag): ?array
     {
-        $lastExecution = time() - 24 * 3600;
+        $lastExecution = (int)file_get_contents($this->fileWithTimestampOfLastExecution) ?: time() - 24 * 3600;
         $taggedQuestionsUrl = $this->apiTagUrl . '&tagged=' . $tag . '&key=' . $this->stackAppsKey . '&fromdate=' . $lastExecution;
         $questions = file_get_contents('compress.zlib://' . $taggedQuestionsUrl);
 
         return json_decode($questions, true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setNewTimestamp(): void
+    {
+        file_put_contents($this->fileWithTimestampOfLastExecution, time());
     }
 }
 
@@ -143,4 +156,8 @@ foreach ($tags as $tag) {
     $newestQuestions = $newPostService->getNewestPostsInStackOverflow($tag);
     $postData = $newPostService->convertQuestionToSlackData($tag, $newestQuestions);
     $newPostService->sendPostToSlack($tag, $postData);
+}
+
+if (!empty($postData)) {
+    $newPostService->setNewTimestamp();
 }

--- a/PostNewQuestions.php
+++ b/PostNewQuestions.php
@@ -20,13 +20,6 @@ class PostNewQuestions
     protected string $stackAppsKey = '';
 
     /**
-     * WebHook URL to channel #stackoverflow
-     *
-     * @var string
-     */
-    protected string $slackUrl = '';
-
-    /**
      * @var string
      */
     protected string $apiTagUrl = 'https://api.stackexchange.com/2.2/questions?site=stackoverflow&filter=withbody&order=asc';


### PR DESCRIPTION
Hi Karsten,

this patch re-implements the usage of the last execution timestamp file but falls back to the time period of "now() - 1 day", if no timestamp file can be found. Like that, we can increase or decrease the job frequency to our likes and at the same never fetch all questions at once. Best of both worlds, hopefully :)

Greetings
Alex